### PR TITLE
add 'alias' method refresh

### DIFF
--- a/colcade.js
+++ b/colcade.js
@@ -208,6 +208,10 @@ proto.onDebouncedResize = function() {
   this._layout();
 };
 
+proto.refresh = function() {
+	this.onDebouncedResize();
+};
+
 proto.onLoad = function( event ) {
   this.measureColumnHeight( event.target );
 };

--- a/colcade.js
+++ b/colcade.js
@@ -142,7 +142,7 @@ proto.layoutItem = function( item ) {
 };
 
 proto.refresh = function() {
-    var activeColumns = this.getActiveColumns();
+  var activeColumns = this.getActiveColumns();
   // check if columns changed
   var isSameLength = activeColumns.length == this.activeColumns.length;
   var isSameColumns = true;

--- a/colcade.js
+++ b/colcade.js
@@ -141,6 +141,22 @@ proto.layoutItem = function( item ) {
   this.columnHeights[ index ] += item.offsetHeight || 1;
 };
 
+proto.refresh = function() {
+    var activeColumns = this.getActiveColumns();
+  // check if columns changed
+  var isSameLength = activeColumns.length == this.activeColumns.length;
+  var isSameColumns = true;
+  this.activeColumns.forEach( function( column, i ) {
+    isSameColumns = isSameColumns && column == activeColumns[i];
+  });
+  if ( isSameLength && isSameColumns ) {
+    return;
+  }
+  // activeColumns changed
+  this.activeColumns = activeColumns;
+  this._layout();
+};
+
 // ----- adding items ----- //
 
 proto.append = function( elems ) {
@@ -192,28 +208,12 @@ proto.onWindowResize = function() {
   }.bind( this ), 100 );
 };
 
-proto.onDebouncedResize = function() {
-  var activeColumns = this.getActiveColumns();
-  // check if columns changed
-  var isSameLength = activeColumns.length == this.activeColumns.length;
-  var isSameColumns = true;
-  this.activeColumns.forEach( function( column, i ) {
-    isSameColumns = isSameColumns && column == activeColumns[i];
-  });
-  if ( isSameLength && isSameColumns ) {
-    return;
-  }
-  // activeColumns changed
-  this.activeColumns = activeColumns;
-  this._layout();
-};
-
-proto.refresh = function() {
-	this.onDebouncedResize();
-};
-
 proto.onLoad = function( event ) {
   this.measureColumnHeight( event.target );
+};
+
+proto.onDebouncedResize = function() {
+  this.refresh();
 };
 
 // ----- destroy ----- //


### PR DESCRIPTION
Creates an alias method 'refresh' to update colcade when (for example) you want to programmatically change the number of columns (nothing new actually it's only a different name for a onDebouncedResize())

hot to use it: $(selector).colcade('refresh')

demo: https://codepen.io/itmandar/pen/zEWKdz