### PR TITLE
Speed optimizations

### DIFF
--- a/colcade.js
+++ b/colcade.js
@@ -144,25 +144,6 @@ proto.layoutItem = function( item ) {
   this.columnHeights[ index ] += item.offsetHeight || 1;
 };
 
-proto.refresh = function() {
-    var activeColumns = this.getActiveColumns();
-  // check if columns changed
-  var isSameLength = activeColumns.length == this.activeColumns.length;
-  var isSameColumns = true;
-  var length = this.activeColumns.length;
-  
-  for (var i = 0; i < length; i++) {
-    isSameColumns = isSameColumns && this.activeColumns[i] == this.activeColumns[i]
-  }
-
-  if ( isSameLength && isSameColumns ) {
-    return;
-  }
-  // activeColumns changed
-  this.activeColumns = activeColumns;
-  this._layout();
-};
-
 // ----- adding items ----- //
 
 proto.append = function( elems ) {
@@ -216,12 +197,27 @@ proto.onWindowResize = function() {
   }.bind( this ), 100 );
 };
 
-proto.onLoad = function( event ) {
-  this.measureColumnHeight( event.target );
+proto.onDebouncedResize = function() {
+    var activeColumns = this.getActiveColumns();
+  // check if columns changed
+  var isSameLength = activeColumns.length == this.activeColumns.length;
+  var isSameColumns = true;
+  var length = this.activeColumns.length;
+  
+  for (var i = 0; i < length; i++) {
+    isSameColumns = isSameColumns && this.activeColumns[i] == this.activeColumns[i]
+  }
+
+  if ( isSameLength && isSameColumns ) {
+    return;
+  }
+  // activeColumns changed
+  this.activeColumns = activeColumns;
+  this._layout();
 };
 
-proto.onDebouncedResize = function() {
-  this.refresh();
+proto.onLoad = function( event ) {
+  this.measureColumnHeight( event.target );
 };
 
 // ----- destroy ----- //

--- a/colcade.js
+++ b/colcade.js
@@ -344,8 +344,11 @@ function makeArray( obj ) {
     ary = obj;
   } else if ( obj && typeof obj.length == 'number' ) {
     // convert nodeList to array
-    for ( var i=0; i < obj.length; i++ ) {
-      ary.push( obj[i] );
+    var length = obj.length;
+    var l = length-1;
+    ary.length = length;
+    for ( var i=l; i >= 0 ; i-- ) {
+      ary[i] =  obj[i];
     }
   } else {
     // array of single index

--- a/colcade.js
+++ b/colcade.js
@@ -99,10 +99,10 @@ proto.updateColumns = function() {
 };
 
 proto.updateItemsHeights = function() {
-  this.itemsHeights = []
-  this.itemsHeights = this.items.map(function(item) {
-    return item.offsetHeight;
-  })
+  this.itemsHeights = [];
+  this.items.forEach(function(item) {
+    this.itemsHeights.push(item.offsetHeight);
+  }, this);
 };
 
 proto.updateItems = function() {

--- a/colcade.js
+++ b/colcade.js
@@ -109,11 +109,22 @@ proto.getActiveColumns = function() {
   });
 };
 
+proto.getActiveColumnsClone = function() {
+    var activeColumnsClone = document.createDocumentFragment()
+    var length = this.activeColumns.length
+    for (var i = 0; i < length; i++) {
+      var li = document.createElement('li')
+      activeColumnsClone.appendChild(li)
+    }
+    return activeColumnsClone.querySelectorAll('li');
+}
+
 // ----- layout ----- //
 
 // public, updates activeColumns
 proto.layout = function() {
   this.activeColumns = this.getActiveColumns();
+  this.activeColumnsClone = this.getActiveColumnsClone();
   this._layout();
 };
 
@@ -132,13 +143,21 @@ proto.layoutItems = function( items ) {
   for (var i = 0; i < length; i++) {
     this.layoutItem(items[i]);
   }
+  this.renderToActiveColumns( this.activeColumnsClone );
 };
+
+proto.renderToActiveColumns = function( items ) {
+    var length = this.activeColumns.length
+    for (let i = 0; i < length; i++) {
+      this.activeColumns[ i ].appendChild( items[ i ] );
+    }
+}
 
 proto.layoutItem = function( item ) {
   // layout item by appending to column
   var minHeight = Math.min.apply( Math, this.columnHeights );
   var index = this.columnHeights.indexOf( minHeight );
-  this.activeColumns[ index ].appendChild( item );
+  this.activeColumnsClone[ index ].appendChild( item );
   // at least 1px, if item hasn't loaded
   // Not exactly accurate, but it's cool
   this.columnHeights[ index ] += item.offsetHeight || 1;
@@ -178,7 +197,7 @@ proto.measureColumnHeight = function( elem ) {
   var boundingRect = this.element.getBoundingClientRect();
   var column;
   var length = this.activeColumns.length;
-  for(var i=length-1; i>=0; i--){ //horribly looking but fast
+  for(var i=0; i < length; i++){ //horribly looking but fast
     column = this.activeColumns[i];
     if ( !elem || column.contains( elem ) ) {
       var lastChildRect = column.lastElementChild.getBoundingClientRect();
@@ -198,7 +217,7 @@ proto.onWindowResize = function() {
 };
 
 proto.onDebouncedResize = function() {
-    var activeColumns = this.getActiveColumns();
+  var activeColumns = this.getActiveColumns();
   // check if columns changed
   var isSameLength = activeColumns.length == this.activeColumns.length;
   var isSameColumns = true;
@@ -225,7 +244,7 @@ proto.onLoad = function( event ) {
 proto.destroy = function() {
   // move items back to container
   var length = this.items.length;
-  for (var i=length-1; i>=0; i--) {
+  for (var i=0; i < length; i++) {
     this.element.prependChild( this.items[i] );
   }
   // remove events
@@ -341,9 +360,8 @@ function makeArray( obj ) {
   } else if ( obj && typeof obj.length == 'number' ) {
     // convert nodeList to array
     var length = obj.length;
-    var l = length-1;
     ary.length = length;
-    for ( var i=l; i >= 0 ; i-- ) {
+    for ( var i=0; i < length ; i++ ) {
       ary[i] =  obj[i];
     }
   } else {

--- a/colcade.js
+++ b/colcade.js
@@ -188,15 +188,15 @@ proto.getQueryItems = function( elems ) {
 
 proto.measureColumnHeight = function( elem ) {
   var boundingRect = this.element.getBoundingClientRect();
-  this.activeColumns.forEach( function( column, i ) {
-    // if elem, measure only that column
-    // if no elem, measure all columns
+  var column, length = this.activeColumns.length;
+  for(var i=length; i>=0; i--){ //horribly looking but fast
+    column = this.activeColumns[i];
     if ( !elem || column.contains( elem ) ) {
       var lastChildRect = column.lastElementChild.getBoundingClientRect();
       // not an exact calculation as it includes top border, and excludes item bottom margin
       this.columnHeights[ i ] = lastChildRect.bottom - boundingRect.top;
     }
-  }, this );
+  }
 };
 
 // ----- events ----- //

--- a/colcade.js
+++ b/colcade.js
@@ -208,6 +208,10 @@ proto.onDebouncedResize = function() {
   this._layout();
 };
 
+proto.refresh = function() {
+	this.onDebouncedResize();
+};
+
 proto.onLoad = function( event ) {
   this.measureColumnHeight( event.target );
 };

--- a/colcade.js
+++ b/colcade.js
@@ -176,12 +176,6 @@ proto.appendColumnNode = function( index, node ) {
   column.appendChild( node );
 };
 
-proto.layoutItem = function( item ) {
-  var index = this.getColumnLayoutIndex();
-  this.updateColumnHeight( index, item );
-  this.appendColumnNode( index, item );
-};
-
 // ----- adding items ----- //
 
 proto.append = function( elems ) {

--- a/colcade.js
+++ b/colcade.js
@@ -141,6 +141,22 @@ proto.layoutItem = function( item ) {
   this.columnHeights[ index ] += item.offsetHeight || 1;
 };
 
+proto.refresh = function() {
+    var activeColumns = this.getActiveColumns();
+  // check if columns changed
+  var isSameLength = activeColumns.length == this.activeColumns.length;
+  var isSameColumns = true;
+  this.activeColumns.forEach( function( column, i ) {
+    isSameColumns = isSameColumns && column == activeColumns[i];
+  });
+  if ( isSameLength && isSameColumns ) {
+    return;
+  }
+  // activeColumns changed
+  this.activeColumns = activeColumns;
+  this._layout();
+};
+
 // ----- adding items ----- //
 
 proto.append = function( elems ) {
@@ -192,28 +208,12 @@ proto.onWindowResize = function() {
   }.bind( this ), 100 );
 };
 
-proto.onDebouncedResize = function() {
-  var activeColumns = this.getActiveColumns();
-  // check if columns changed
-  var isSameLength = activeColumns.length == this.activeColumns.length;
-  var isSameColumns = true;
-  this.activeColumns.forEach( function( column, i ) {
-    isSameColumns = isSameColumns && column == activeColumns[i];
-  });
-  if ( isSameLength && isSameColumns ) {
-    return;
-  }
-  // activeColumns changed
-  this.activeColumns = activeColumns;
-  this._layout();
-};
-
-proto.refresh = function() {
-	this.onDebouncedResize();
-};
-
 proto.onLoad = function( event ) {
   this.measureColumnHeight( event.target );
+};
+
+proto.onDebouncedResize = function() {
+  this.refresh();
 };
 
 // ----- destroy ----- //

--- a/colcade.js
+++ b/colcade.js
@@ -197,7 +197,7 @@ proto.measureColumnHeight = function( elem ) {
   var boundingRect = this.element.getBoundingClientRect();
   var column;
   var length = this.activeColumns.length;
-  for(var i=length; i>=0; i--){ //horribly looking but fast
+  for(var i=length-1; i>=0; i--){ //horribly looking but fast
     column = this.activeColumns[i];
     if ( !elem || column.contains( elem ) ) {
       var lastChildRect = column.lastElementChild.getBoundingClientRect();
@@ -229,7 +229,7 @@ proto.onDebouncedResize = function() {
 proto.destroy = function() {
   // move items back to container
   var length = this.items.length;
-  for (var i=length; i>=0; i--) {
+  for (var i=length-1; i>=0; i--) {
     this.element.prependChild( this.items[i] );
   }
   // remove events

--- a/colcade.js
+++ b/colcade.js
@@ -128,7 +128,10 @@ proto._layout = function() {
 };
 
 proto.layoutItems = function( items ) {
-  items.forEach( this.layoutItem, this );
+  var length = items.length;
+  for (var i = 0; i < length; i++) {
+    this.layoutItem(items[i]);
+  }
 };
 
 proto.layoutItem = function( item ) {
@@ -146,9 +149,12 @@ proto.refresh = function() {
   // check if columns changed
   var isSameLength = activeColumns.length == this.activeColumns.length;
   var isSameColumns = true;
-  this.activeColumns.forEach( function( column, i ) {
-    isSameColumns = isSameColumns && column == activeColumns[i];
-  });
+  var length = this.activeColumns.length;
+  
+  for (var i = 0; i < length; i++) {
+    isSameColumns = isSameColumns && this.activeColumns[i] == this.activeColumns[i]
+  }
+
   if ( isSameLength && isSameColumns ) {
     return;
   }
@@ -178,9 +184,10 @@ proto.prepend = function( elems ) {
 proto.getQueryItems = function( elems ) {
   elems = makeArray( elems );
   var fragment = document.createDocumentFragment();
-  elems.forEach( function( elem ) {
-    fragment.appendChild( elem );
-  });
+  var length = elems.length;
+  for(var i=0; i<length; i++) {
+    fragment.appendChild( elems[i] );
+  }
   return querySelect( this.options.items, fragment );
 };
 
@@ -221,9 +228,10 @@ proto.onDebouncedResize = function() {
 
 proto.destroy = function() {
   // move items back to container
-  this.items.forEach( function( item ) {
-    this.element.appendChild( item );
-  }, this );
+  var length = this.items.length;
+  for (var i=length; i>=0; i--) {
+    this.element.prependChild( this.items[i] );
+  }
   // remove events
   window.removeEventListener( 'resize', this._windowResizeHandler );
   this.element.removeEventListener( 'load', this._loadHandler, true );
@@ -236,7 +244,10 @@ proto.destroy = function() {
 
 docReady( function() {
   var dataElems = querySelect('[data-colcade]');
-  dataElems.forEach( htmlInit );
+  var length = dataElems.length;
+  for (var i=0; i<length; i++) {
+    htmlInit( dataElems[i] )
+  }
 });
 
 function htmlInit( elem ) {
@@ -244,12 +255,13 @@ function htmlInit( elem ) {
   var attr = elem.getAttribute('data-colcade');
   var attrParts = attr.split(',');
   var options = {};
-  attrParts.forEach( function( part ) {
-    var pair = part.split(':');
+  var length = attrParts.length;
+  for (var i=0; i<length; i++) {
+    var pair = attrParts[i].split(':');
     var key = pair[0].trim();
     var value = pair[1].trim();
     options[ key ] = value;
-  });
+  }
 
   new Colcade( elem, options );
 }

--- a/colcade.js
+++ b/colcade.js
@@ -98,8 +98,16 @@ proto.updateColumns = function() {
   this.columns = querySelect( this.options.columns, this.element );
 };
 
+proto.updateItemsHeights = function() {
+  this.itemsHeights = []
+  this.itemsHeights = this.items.map(function(item) {
+    return item.offsetHeight;
+  })
+};
+
 proto.updateItems = function() {
   this.items = querySelect( this.options.items, this.element );
+  this.updateItemsHeights();
 };
 
 proto.getActiveColumns = function() {
@@ -131,7 +139,7 @@ proto.layoutItems = function( items ) {
 
   var columnFragments = {};
 
-  items.forEach( function( item ) {
+  items.forEach( function( item, itemIndex ) {
     var index = this.getColumnLayoutIndex();
     // add item to fragment
     var fragment = columnFragments[ index ];
@@ -141,7 +149,7 @@ proto.layoutItems = function( items ) {
     }
     fragment.appendChild( item );
 
-    this.updateColumnHeight( index, item );
+    this.updateColumnHeight( index, itemIndex );
   }, this);
 
   // append fragments to columns
@@ -157,10 +165,10 @@ proto.getColumnLayoutIndex = function() {
   return index;
 };
 
-proto.updateColumnHeight = function( index, item ) {
+proto.updateColumnHeight = function( index, itemIndex ) {
   // at least 1px, if item hasn't loaded
   // Not exactly accurate, but it's cool
-  this.columnHeights[ index ] += item.offsetHeight || 1;
+  this.columnHeights[ index ] += this.itemsHeights[itemIndex] || 1;
 };
 
 proto.appendColumnNode = function( index, node ) {


### PR DESCRIPTION
PHASE 1 - so following this test... https://jsbench.me/lbj8m1fwn3/1 I decided to change forEach loops to for loops (~13% faster) to see if there's some visible speed improvs, i know this will make the code look ugly, but in some cases the improvement is quite good (~400ms in my test case).

PHASE2 - I noticed that layoutItem() appends each item causing a forced reflow for each single masonry item (https://gist.github.com/paulirish/5d52fb081b3570c81e3a), so I modified the layout() method using fragments to avoid that https://developer.mozilla.org/en-US/docs/Web/API/Document/createDocumentFragment, there are major speed improvements (~4x faster in my test case) especially in a masonry with 200 elements or more