### PR TITLE
add option for leaving DOM untouched when calling destroy

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,15 @@ $grid.colcade('destroy')
 colc.destroy()
 ```
 
+Remove event listeners and instances, but preserve DOM as is.
+
+``` js
+// jQuery
+$grid.colcade('destroy', false)
+// vanilla JS
+colc.destroy(false)
+```
+
 ---
 
 By David DeSandro

--- a/colcade.js
+++ b/colcade.js
@@ -214,11 +214,13 @@ proto.onLoad = function( event ) {
 
 // ----- destroy ----- //
 
-proto.destroy = function() {
-  // move items back to container
-  this.items.forEach( function( item ) {
-    this.element.appendChild( item );
-  }, this );
+proto.destroy = function(moveItemsBack = true) {
+  if(moveItemsBack) {
+    // move items back to container
+    this.items.forEach( function( item ) {
+      this.element.appendChild( item );
+    }, this );
+  }
   // remove events
   window.removeEventListener( 'resize', this._windowResizeHandler );
   this.element.removeEventListener( 'load', this._loadHandler, true );


### PR DESCRIPTION
## Context

- We are using Rails with [Stimulus](url) & [Turbolinks ](https://github.com/turbolinks/turbolinks), which uses JavaScript to ajax in new pages instead of refreshing the page when navigating a site.
- That means that any instances and listeners are also persisted when moving to another page.
- Rails also [caches pages](https://github.com/turbolinks/turbolinks#understanding-caching) to speed up page loads, so when leaving a page the contents are cached, and upon revisiting it, those contents are loaded.

## Problem

When using Colcade, this is the problem we run into:

1. Colcade instances keep track of the element they are connected to using [`element.colcadeGUID`](https://github.com/desandro/colcade/blob/master/colcade.js#L60-L63).
2. This GUID value gets removed when leaving a page with Turbolinks.
3. The _Colcade instance_ itself, however, sticks around.
4. When we come back to the cached page, if we just initialize a _new_ Colcade instance, we will have an ever increasing number of instances:
  ![Screen Shot 2019-06-20 at 16 40 27](https://user-images.githubusercontent.com/104138/59985496-fe624c00-966c-11e9-86e7-b23b57b3d40e.png)
5. Colcade [has a way of reusing existing instances](https://github.com/desandro/colcade/blob/master/colcade.js#L32-L37), so I explored caching and resetting the `colcadeGUID` to make use of that like this:
  ```js
  disconnect() {
    this.data.set("colcateGUID", this.grid.colcadeGUID)
  }

  _initializeMasonry() {
    this.grid.colcateGUID = this.data.get("colcateGUID")
    this.colcade = new Colcade(...)
  }
  ```
6. However, the existing instance would be associated with columns _no longer on the page_, as they were removed by Turbolinks (and then added back in when the page is reopened). We would have to manually tell Colcade what the columns are again.
8. I then thought, "ok, maybe we can just destroy the instance completely on `stimulus#disconnect()`, and start over when we come back to the page?".
9. Colcade has a [`destroy`](https://github.com/desandro/colcade/blob/master/colcade.js#L217-L228) method that does just that, but it _also_ moves any items back to their non-masonry positions.
10. This isn't visible in the browser _but_...it _does_ appear to visible to the Turbolinks logic that _remembers scroll position_.
11. That means, that just before leaving the page, to Turbolinks it looks like this:
![Screen Shot 2019-06-24 at 10 57 01](https://user-images.githubusercontent.com/104138/59985898-04592c80-966f-11e9-99e4-44be4a2fdeec.png)
12. Then, when going back, even if we re-initialize the masonry layout, the scroll position would always be slightly off:

<img src=https://user-images.githubusercontent.com/104138/59985999-9fea9d00-966f-11e9-878e-d816488287db.gif width=400>

## Fix

Provide an option to `destroy` that allows us to remove instances/listeners, but leaves the DOM untouched (does not move items back outside the columns.)

Let me know if I'm completely misguided here or there is a better way! 🙏 