### PR TITLE
add handling for no active columns

### DIFF
--- a/colcade.js
+++ b/colcade.js
@@ -132,6 +132,11 @@ proto.layoutItems = function( items ) {
 };
 
 proto.layoutItem = function( item ) {
+  // skip if no column is active
+  if (!this.activeColumns.length) {
+    return;
+  }
+
   // layout item by appending to column
   var minHeight = Math.min.apply( Math, this.columnHeights );
   var index = this.columnHeights.indexOf( minHeight );


### PR DESCRIPTION
Right now Colcade needs always an active column to work without errors.
But sometimes you don't want to have an active column on some viewports (without destroying colcade), so it makes sense to add a handling for this.